### PR TITLE
Upgrade to compile with SDK 3.0

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -149,12 +149,16 @@
             }
         ]
     },
-    "sdkVersion": "2",
+    "sdkVersion": "3",
     "shortName": "Rockodi",
     "uuid": "77495959-66fe-4db1-ab4b-368369babb00",
     "versionCode": 1,
     "versionLabel": "0.1",
     "watchapp": {
         "watchface": false
-    }
+    },
+    "targetPlatforms": [
+        "aplite",
+        "basalt"
+    ]
 }

--- a/src/addons.c
+++ b/src/addons.c
@@ -60,7 +60,7 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     dict_write_cstring(&items_iter, (int) t->key, (char*) t->value->cstring);
     t = dict_read_next(iterator);
   }
-  int items_size = dict_write_end(&items_iter);
+  //int items_size = dict_write_end(&items_iter);
   load_menu();
 }
 
@@ -76,7 +76,9 @@ static void menu_select_cb(MenuLayer *menu_layer, MenuIndex *cell_index, BasicMe
 
 static void initialize_ui(void) {
   s_window = window_create();
+#ifdef PBL_SDK_2
   window_set_fullscreen(s_window, false);
+#endif
   window_set_background_color(s_window, GColorBlack);
   Layer *window_layer = window_get_root_layer(s_window);
   GRect bounds = layer_get_frame(window_layer);

--- a/src/config.c
+++ b/src/config.c
@@ -26,7 +26,9 @@ static Window *s_window;
 
 static void initialize_ui(void) {
   s_window = window_create();
+#ifdef PBL_SDK_2
   window_set_fullscreen(s_window, false);
+#endif
   window_set_background_color(s_window, GColorBlack);
   Layer *window_layer = window_get_root_layer(s_window);
   GRect bounds = layer_get_frame(window_layer);

--- a/src/goto.c
+++ b/src/goto.c
@@ -50,7 +50,9 @@ static void initialize_ui(void) {
   s_icon_weather = gbitmap_create_with_resource(RESOURCE_ID_ICON_WEATHER);
 
   s_window = window_create();
+#ifdef PBL_SDK_2
   window_set_fullscreen(s_window, false);
+#endif
   window_set_background_color(s_window, GColorBlack);
   Layer *window_layer = window_get_root_layer(s_window);
   GRect bounds = layer_get_frame(window_layer);

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -53,7 +53,9 @@ static void initialize_ui(void) {
   s_icon_power = gbitmap_create_with_resource(RESOURCE_ID_ICON_POWER);
 
   s_window = window_create();
+#ifdef PBL_SDK_2
   window_set_fullscreen(s_window, false);
+#endif
   window_set_background_color(s_window, GColorBlack);
   Layer *window_layer = window_get_root_layer(s_window);
   GRect bounds = layer_get_frame(window_layer);

--- a/src/player.c
+++ b/src/player.c
@@ -114,7 +114,9 @@ static void player_tap_cb(AccelAxisType axis, int32_t direction) {
 
 static void initialize_ui() {
   s_window = window_create();
+#ifdef PBL_SDK_2
   window_set_fullscreen(s_window, false);
+#endif
   window_set_background_color(s_window, GColorBlack);
   Layer *window_layer = window_get_root_layer(s_window);
   GRect bounds = layer_get_frame(window_layer);

--- a/src/playlists.c
+++ b/src/playlists.c
@@ -75,7 +75,9 @@ static void menu_select_cb(MenuLayer *menu_layer, MenuIndex *cell_index, BasicMe
 
 static void initialize_ui(void) {
   s_window = window_create();
+#ifdef PBL_SDK_2
   window_set_fullscreen(s_window, false);
+#endif
   window_set_background_color(s_window, GColorBlack);
   Layer *window_layer = window_get_root_layer(s_window);
   GRect bounds = layer_get_frame(window_layer);

--- a/src/power.c
+++ b/src/power.c
@@ -34,7 +34,9 @@ static void menu_select_cb(MenuLayer *menu_layer, MenuIndex *cell_index, BasicMe
 
 static void initialize_ui(void) {
   s_window = window_create();
+#ifdef PBL_SDK_2
   window_set_fullscreen(s_window, false);
+#endif
   window_set_background_color(s_window, GColorBlack);
   Layer *window_layer = window_get_root_layer(s_window);
   GRect bounds = layer_get_frame(window_layer);

--- a/src/remote.c
+++ b/src/remote.c
@@ -48,7 +48,9 @@ static void click_provider(void *context)
 
 static void initialize_ui() {
   s_window = buttons_window_create();
+#ifdef PBL_SDK_2
   window_set_fullscreen(s_window, false);
+#endif
   Layer *window_layer = window_get_root_layer(s_window);
 
   s_icon_cursor_up = gbitmap_create_with_resource(RESOURCE_ID_ICON_CURSOR_UP);

--- a/wscript
+++ b/wscript
@@ -6,11 +6,6 @@
 #
 
 import os.path
-try:
-    from sh import CommandNotFound, jshint, cat, ErrorReturnCode_2
-    hint = jshint
-except (ImportError, CommandNotFound):
-    hint = None
 
 top = '.'
 out = 'build'
@@ -20,38 +15,27 @@ def options(ctx):
 
 def configure(ctx):
     ctx.load('pebble_sdk')
-    global hint
-    if hint is not None:
-        hint = hint.bake(['--config', 'pebble-jshintrc'])
 
 def build(ctx):
-    if False and hint is not None:
-        try:
-            hint([node.abspath() for node in ctx.path.ant_glob("src/**/*.js")], _tty_out=False) # no tty because there are none in the cloudpebble sandbox.
-        except ErrorReturnCode_2 as e:
-            ctx.fatal("\nJavaScript linting failed (you can disable this in Project Settings):\n" + e.stdout)
-
-    # Concatenate all our JS files (but not recursively), and only if any JS exists in the first place.
-    ctx.path.make_node('src/js/').mkdir()
-    js_paths = ctx.path.ant_glob(['src/*.js', 'src/**/*.js'])
-    if js_paths:
-        ctx(rule='cat ${SRC} > ${TGT}', source=js_paths, target='pebble-js-app.js')
-        has_js = True
-    else:
-        has_js = False
-
     ctx.load('pebble_sdk')
 
-    ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
-                    target='pebble-app.elf')
+    build_worker = os.path.exists('worker_src')
+    binaries = []
 
-    if os.path.exists('worker_src'):
-        ctx.pbl_worker(source=ctx.path.ant_glob('worker_src/**/*.c'),
-                        target='pebble-worker.elf')
-        ctx.pbl_bundle(elf='pebble-app.elf',
-                        worker_elf='pebble-worker.elf',
-                        js='pebble-js-app.js' if has_js else [])
-    else:
-        ctx.pbl_bundle(elf='pebble-app.elf',
-                       js='pebble-js-app.js' if has_js else [])
+    for p in ctx.env.TARGET_PLATFORMS:
+        ctx.set_env(ctx.all_envs[p])
+        ctx.set_group(ctx.env.PLATFORM_NAME)
+        app_elf='{}/pebble-app.elf'.format(ctx.env.BUILD_DIR)
+        ctx.pbl_program(source=ctx.path.ant_glob('src/**/*.c'),
+        target=app_elf)
 
+        if build_worker:
+            worker_elf='{}/pebble-worker.elf'.format(ctx.env.BUILD_DIR)
+            binaries.append({'platform': p, 'app_elf': app_elf, 'worker_elf': worker_elf})
+            ctx.pbl_worker(source=ctx.path.ant_glob('worker_src/**/*.c'),
+            target=worker_elf)
+        else:
+            binaries.append({'platform': p, 'app_elf': app_elf})
+
+    ctx.set_group('bundle')
+    ctx.pbl_bundle(binaries=binaries, js=ctx.path.ant_glob('src/js/**/*.js'))


### PR DESCRIPTION
These are some small changes created by running `pebble convert-project` and commenting and ifdeffing out some warning-creating code that stops compilation on SDK 3.0.

The text is now readable once the menu item is selected. Will try to make it work like it originally did. 

Tested on Pebble Time Steel but not on original Pebble.

(convert-project also changed the spacing in appinfo.json, tabs should now be 2 spaces instead of 4, but changed it back to keep the patch clean)
